### PR TITLE
Add block style buttons that expand to the width of the parent.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@ Cerner Corporation
 - Matt Butler [@matt-butler]
 - Rory Hardy [@gneatgeek]
 - Tao Zhang [@windse7en]
-
+- Tatiana Alexenko [@bunnyLord]
 
 
 [@bjankord]: https://github.com/bjankord
@@ -13,3 +13,4 @@ Cerner Corporation
 [@matt-butler]: https://github.com/matt-butler
 [@gneatgeek]: https://github.com/gneatgeek
 [@windse7en]:https://github.com/windse7en
+[@bunnyLord]:https://github.com/bunnyLord

--- a/docs/terra-button-size.md
+++ b/docs/terra-button-size.md
@@ -9,3 +9,4 @@ Buttons can be sized by placing any of the following classes on the `terra-Butto
 | `terra-Button--medium`  | Adjusts the `font-size` of the button according to the specified medium button `font-size` value |
 | `terra-Button--large`   | Adjusts the `font-size` of the button according to the specified large button `font-size` value  |
 | `terra-Button--huge`    | Adjusts the `font-size` of the button according to the specified huge button `font-size` value   |
+| `terra-Button--block`   | Adjusts the `width` and `display` of the button to make it span the full width of the parent     |   

--- a/src/terra-button.scss
+++ b/src/terra-button.scss
@@ -170,3 +170,8 @@ input[type='submit'].terra-Button {
 .terra-Button--huge {
   font-size: map-get($terra-button-font-sizes, huge);
 }
+
+.terra-Button--block {
+  display: block;
+  width: 100%;
+}

--- a/tests/visual/terra-button-size.html
+++ b/tests/visual/terra-button-size.html
@@ -3,3 +3,4 @@
 <button class="terra-Button terra-Button--default terra-Button--medium">Medium</button>
 <button class="terra-Button terra-Button--default terra-Button--large">Large</button>
 <button class="terra-Button terra-Button--default terra-Button--huge">Huge</button>
+<button class="terra-Button terra-Button--default terra-Button--block">Block</button>


### PR DESCRIPTION
### Summary
Added block-style buttons that expand to fill the width of the parent. 
Added documentation and a test for this new style. 
### Additional Details
I am still unsure if we need `display: block` for the button-block style. I did some local tests with text around the button and did not notice a difference. Currently the button will inherit the inline-block style from the parent button class.
The other thing that might need to be thought about is whether the block style belongs in the button-size section since the button-size styles are all based on font size. 